### PR TITLE
Permit react-native and react-native-blur patches

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   },
   "homepage": "https://github.com/lelandrichardson/react-native-parallax-view",
   "dependencies": {
-    "react-native-blur": "^0.4.1"
+    "react-native-blur": "^0.4.x"
   },
   "peerDependencies": {
-    "react-native": "^0.4.1"
+    "react-native": "^0.4.x"
   }
 }


### PR DESCRIPTION
I had some trouble installing this package because my version of React was slightly newer (0.4.4 vs 0.4.1). Assuming React Native is using semantic versioning, patches to 0.4 should remain compatible with react-native-parallax-view.
