### PR TITLE
Expose onScroll event

### DIFF
--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -54,6 +54,16 @@ var ParallaxView = React.createClass({
       this._scrollView.setNativeProps(props);
     },
 
+    handleScroll(ev) {
+      var { onScroll } = this.props;
+
+      if (typeof onScroll === 'function') {
+        onScroll(ev);
+      }
+
+      return Animated.event([{ nativeEvent: { contentOffset: { y: this.state.scrollY }}}])(ev);
+    },
+
     renderBackground: function () {
         var { windowHeight, backgroundSource, blur } = this.props;
         var { scrollY } = this.state;
@@ -114,9 +124,7 @@ var ParallaxView = React.createClass({
                     ref={component => { this._scrollView = component; }}
                     {...props}
                     style={styles.scrollView}
-                    onScroll={Animated.event(
-                      [{ nativeEvent: { contentOffset: { y: this.state.scrollY }}}]
-                    )}
+                    onScroll={ this.handleScroll }
                     scrollEventThrottle={16}>
                     {this.renderHeader()}
                     <View style={styles.content}>


### PR DESCRIPTION
If you pass onScroll to ParallaxView as a prop it gets overwritten at component level (there is already onScroll that handles parallax animation).

This allows you to extend it.
