### PR TITLE
Fix overlay using with ToolbarAndroid

### DIFF
--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -131,6 +131,7 @@ var ParallaxView = React.createClass({
 var styles = StyleSheet.create({
     container: {
         flex: 1,
+        borderColor: 'transparent',
     },
     scrollView: {
         backgroundColor: 'transparent',


### PR DESCRIPTION
Because parent-view is not cropping, when use in Android, where we've a ToolbarAndroid component in the top, headerBackgroundImage is over ToolbarAndroid.

With this small add in your styles, it's solved :ok_hand: 
