### PR TITLE
fixed backgroundSource Type warning

### DIFF
--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -22,7 +22,13 @@ var ParallaxView = React.createClass({
     propTypes: {
         ...ScrollViewPropTypes,
         windowHeight: React.PropTypes.number,
-        backgroundSource: React.PropTypes.object,
+        backgroundSource: React.PropTypes.oneOfType([
+          React.PropTypes.shape({
+            uri: React.PropTypes.string,
+          }),
+          // Opaque type returned by require('./image.jpg')
+          React.PropTypes.number,
+        ]),
         header: React.PropTypes.node,
         blur: React.PropTypes.string,
         contentInset: React.PropTypes.object,


### PR DESCRIPTION
fixed `backgroundSource` Type warning when use `require('./image.jpg')`
