### PR TITLE
refine imports

### DIFF
--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var React = require('react-native');
+var React = require('react');
 var {
     Dimensions,
     StyleSheet,
     View,
     ScrollView,
     Animated,
-    } = React;
+    } = require('react-native');
 /**
  * BlurView temporarily removed until semver stuff is set up properly
  */


### PR DESCRIPTION
As from react-native 0.26.0, API needs to be imported separately for react and react-native.
see https://github.com/facebook/react-native/releases/tag/v0.26.0 for more information.
