### PR TITLE
Add optional custom listener if needed

### DIFF
--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -123,7 +123,8 @@ var ParallaxView = React.createClass({
                     {...props}
                     style={styles.scrollView}
                     onScroll={Animated.event(
-                      [{ nativeEvent: { contentOffset: { y: this.state.scrollY }}}]
+                      [{ nativeEvent: { contentOffset: { y: this.state.scrollY }}}],
+                      {listener: this.props.onScroll}
                     )}
                     scrollEventThrottle={16}>
                     {this.renderHeader()}


### PR DESCRIPTION
If a user wants to specify or access onScroll of the ScrollView, they should be able to add their own listener callback.
