### PR TITLE
Add `backgroundStyle` prop to customise styling of background image

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NOTE: I will put up an rnplay.org working example whenever they support React Na
 
 ## Example
 
-There is a working example in the project `/example` folder that you can check out. Remember to run npm install inside 
+There is a working example in the project `/example` folder that you can check out. Remember to run npm install inside
 the example folder if you'd like to run that project.
 
 ```bash
@@ -53,4 +53,5 @@ Additionally, here is an example of the usage
 | header | NO | `null` | `renderable` | any content you want to render on top of the image. This content's opacity get's animated down as the scrollview scrolls up. (optional) |
 | windowHeight | NO | `300` | `number` | the resting height of the header image. If 0 is passed in, the background is not rendered. |
 | scrollableViewStyle | NO | `null` | `object` | this style will be mixed (overriding existing fields) with scrollable view style (view which is scrolled over the background) |
+| backgroundStyle | NO | `null` | `object` | this style will be mixed (overriding existing fields) with background style |
 | ... | NO | | `...ScrollViewProps` | `{...this.props}` is applied on the internal `ScrollView` (excluding the `style` prop which is passed on to the outer container) |

--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -125,7 +125,8 @@ var ParallaxView = React.createClass({
                     {...props}
                     style={styles.scrollView}
                     onScroll={Animated.event(
-                      [{ nativeEvent: { contentOffset: { y: this.state.scrollY }}}]
+                      [{ nativeEvent: { contentOffset: { y: this.state.scrollY }}}],
+                      { listener: props.onScroll }
                     )}
                     scrollEventThrottle={16}>
                     {this.renderHeader()}

--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -33,6 +33,7 @@ var ParallaxView = React.createClass({
         header: React.PropTypes.node,
         blur: React.PropTypes.string,
         contentInset: React.PropTypes.object,
+        backgroundStyle: React.PropTypes.object
     },
 
     getDefaultProps: function () {
@@ -63,14 +64,14 @@ var ParallaxView = React.createClass({
     },
 
     renderBackground: function () {
-        var { windowHeight, backgroundSource, blur } = this.props;
+        var { windowHeight, backgroundSource, blur, backgroundStyle } = this.props;
         var { scrollY } = this.state;
         if (!windowHeight || !backgroundSource) {
             return null;
         }
         return (
             <Animated.Image
-                style={[styles.background, {
+                style={[styles.background, backgroundStyle, {
                     height: windowHeight,
                     transform: [{
                         translateY: scrollY.interpolate({

--- a/lib/ParallaxView.js
+++ b/lib/ParallaxView.js
@@ -41,7 +41,8 @@ var ParallaxView = React.createClass({
             windowHeight: 300,
             contentInset: {
                 top: screen.scale
-            }
+            },
+            backgroundStyle: null,
         };
     },
 


### PR DESCRIPTION
This PR adds a `backgroundStyle` prop that allows to customise the styling of the background. We, for example, want to change the background color while the image is loading.